### PR TITLE
feat: add brazilian black awareness day

### DIFF
--- a/definitions/br.yaml
+++ b/definitions/br.yaml
@@ -48,6 +48,9 @@ months:
   - name: Proclamação da República
     regions: [br]
     mday: 15
+  - name: Dia da Consciência Negra
+    regions: [br]
+    mday: 20
   12:
   - name: Natal
     regions: [br]
@@ -69,6 +72,7 @@ tests: |
      Date.civil(2008,10,12) => 'Dia de Nossa Senhora Aparecida',
      Date.civil(2008,11,2) => 'Dia de Finados',
      Date.civil(2008,11,15) => 'Proclamação da República',
+     Date.civil(2008,11,20) => 'Dia da Consciência Negra'
      Date.civil(2008,12,25) => 'Natal'}.each do |date, name|
       assert_equal name, (Holidays.on(date, :br, :informal)[0] || {})[:name]
     end

--- a/definitions/br.yaml
+++ b/definitions/br.yaml
@@ -1,7 +1,7 @@
 # Brazilian holiday definitions for the Ruby Holiday gem.
 # Provided by Rogério Carrasqueira
 #
-# Updated: 2008-11-28.
+# Updated: 2025-08-08.
 # Sources:
 # - http://pt.wikipedia.org/wiki/Feriados_no_Brasil
 

--- a/lib/holidays/definitions/br.ex
+++ b/lib/holidays/definitions/br.ex
@@ -5,82 +5,77 @@ defmodule Holidays.Definitions.Br do
 
   @moduledoc """
   Brazil holiday definitions.
-
+  
   # Updated: 2018-09-25.
   # Sources:
   # - https://pt.wikipedia.org/wiki/Feriados_no_Brasil
 
   """
   def init() do
-    holiday(
-      "Confraternização Universal",
-      %{month: 1, day: 1, regions: [:br]}
-    )
+    holiday "Confraternização Universal",
+      %{month: 1,
+        day: 1,
+        regions: [:br]}
 
-    holiday(
-      "Tiradentes",
-      %{month: 4, day: 21, regions: [:br]}
-    )
+    holiday "Tiradentes",
+      %{month: 4,
+        day: 21,
+        regions: [:br]}
 
-    holiday(
-      "Dia do Trabalhador",
-      %{month: 5, day: 1, regions: [:br]}
-    )
+    holiday "Dia do Trabalhador",
+      %{month: 5,
+        day: 1,
+        regions: [:br]}
 
-    holiday(
-      "Proclamação da Independência",
-      %{month: 9, day: 7, regions: [:br]}
-    )
+    holiday "Proclamação da Independência",
+      %{month: 9,
+        day: 7,
+        regions: [:br]}
 
-    holiday(
-      "Nossa Senhora Aparecida",
-      %{month: 10, day: 12, regions: [:br]}
-    )
+    holiday "Nossa Senhora Aparecida",
+      %{month: 10,
+        day: 12,
+        regions: [:br]}
 
-    holiday(
-      "Finados",
-      %{month: 11, day: 2, regions: [:br]}
-    )
+    holiday "Finados",
+      %{month: 11,
+        day: 2,
+        regions: [:br]}
 
-    holiday(
-      "Proclamação da República",
-      %{month: 11, day: 15, regions: [:br]}
-    )
+    holiday "Proclamação da República",
+      %{month: 11,
+        day: 15,
+        regions: [:br]}
 
-    holiday(
-      "Dia da Consciência Negra",
-      %{month: 11, day: 20, regions: [:br]}
-    )
+    holiday "Dia da Consciência Negra",
+        %{month: 11,
+          day: 20,
+          regions: [:br]}
 
-    holiday(
-      "Natal",
-      %{month: 12, day: 25, regions: [:br]}
-    )
+    holiday "Natal",
+      %{month: 12,
+        day: 25,
+        regions: [:br]}
 
-    holiday(
-      "Carnaval",
-      %{function: {Holidays, :easter, [:year], -47}, regions: [:br]}
-    )
+    holiday "Carnaval",
+      %{function: {Holidays, :easter, [:year], -47},
+        regions: [:br]}
 
-    holiday(
-      "Sexta-feira santa",
-      %{function: {Holidays, :easter, [:year], -2}, regions: [:br]}
-    )
+    holiday "Sexta-feira santa",
+      %{function: {Holidays, :easter, [:year], -2},
+        regions: [:br]}
 
-    holiday(
-      "Páscoa",
-      %{function: {Holidays, :easter, [:year]}, regions: [:br]}
-    )
+    holiday "Páscoa",
+      %{function: {Holidays, :easter, [:year]},
+        regions: [:br]}
 
-    holiday(
-      "Corpus Christi",
-      %{function: {Holidays, :easter, [:year], 60}, regions: [:br]}
-    )
+    holiday "Corpus Christi",
+      %{function: {Holidays, :easter, [:year], 60},
+        regions: [:br]}
 
-    holiday(
-      "Eleições",
-      %{function: {Holidays.Definitions.Br, :election_day, [:year]}, regions: [:br]}
-    )
+    holiday "Eleições",
+      %{function: {Holidays.Definitions.Br, :election_day, [:year]},
+        regions: [:br]}
   end
 
   @doc """

--- a/lib/holidays/definitions/br.ex
+++ b/lib/holidays/definitions/br.ex
@@ -5,72 +5,82 @@ defmodule Holidays.Definitions.Br do
 
   @moduledoc """
   Brazil holiday definitions.
-  
+
   # Updated: 2018-09-25.
   # Sources:
   # - https://pt.wikipedia.org/wiki/Feriados_no_Brasil
 
   """
   def init() do
-    holiday "Confraternização Universal",
-      %{month: 1,
-        day: 1,
-        regions: [:br]}
+    holiday(
+      "Confraternização Universal",
+      %{month: 1, day: 1, regions: [:br]}
+    )
 
-    holiday "Tiradentes",
-      %{month: 4,
-        day: 21,
-        regions: [:br]}
+    holiday(
+      "Tiradentes",
+      %{month: 4, day: 21, regions: [:br]}
+    )
 
-    holiday "Dia do Trabalhador",
-      %{month: 5,
-        day: 1,
-        regions: [:br]}
+    holiday(
+      "Dia do Trabalhador",
+      %{month: 5, day: 1, regions: [:br]}
+    )
 
-    holiday "Proclamação da Independência",
-      %{month: 9,
-        day: 7,
-        regions: [:br]}
+    holiday(
+      "Proclamação da Independência",
+      %{month: 9, day: 7, regions: [:br]}
+    )
 
-    holiday "Nossa Senhora Aparecida",
-      %{month: 10,
-        day: 12,
-        regions: [:br]}
+    holiday(
+      "Nossa Senhora Aparecida",
+      %{month: 10, day: 12, regions: [:br]}
+    )
 
-    holiday "Finados",
-      %{month: 11,
-        day: 2,
-        regions: [:br]}
+    holiday(
+      "Finados",
+      %{month: 11, day: 2, regions: [:br]}
+    )
 
-    holiday "Proclamação da República",
-      %{month: 11,
-        day: 15,
-        regions: [:br]}
+    holiday(
+      "Proclamação da República",
+      %{month: 11, day: 15, regions: [:br]}
+    )
 
-    holiday "Natal",
-      %{month: 12,
-        day: 25,
-        regions: [:br]}
+    holiday(
+      "Dia da Consciência Negra",
+      %{month: 11, day: 20, regions: [:br]}
+    )
 
-    holiday "Carnaval",
-      %{function: {Holidays, :easter, [:year], -47},
-        regions: [:br]}
+    holiday(
+      "Natal",
+      %{month: 12, day: 25, regions: [:br]}
+    )
 
-    holiday "Sexta-feira santa",
-      %{function: {Holidays, :easter, [:year], -2},
-        regions: [:br]}
+    holiday(
+      "Carnaval",
+      %{function: {Holidays, :easter, [:year], -47}, regions: [:br]}
+    )
 
-    holiday "Páscoa",
-      %{function: {Holidays, :easter, [:year]},
-        regions: [:br]}
+    holiday(
+      "Sexta-feira santa",
+      %{function: {Holidays, :easter, [:year], -2}, regions: [:br]}
+    )
 
-    holiday "Corpus Christi",
-      %{function: {Holidays, :easter, [:year], 60},
-        regions: [:br]}
+    holiday(
+      "Páscoa",
+      %{function: {Holidays, :easter, [:year]}, regions: [:br]}
+    )
 
-    holiday "Eleições",
-      %{function: {Holidays.Definitions.Br, :election_day, [:year]},
-        regions: [:br]}
+    holiday(
+      "Corpus Christi",
+      %{function: {Holidays, :easter, [:year], 60}, regions: [:br]}
+    )
+
+    holiday(
+      "Eleições",
+      %{function: {Holidays.Definitions.Br, :election_day, [:year]}, regions: [:br]}
+    )
   end
 
   @doc """

--- a/test/holidays/definitions/br_test.exs
+++ b/test/holidays/definitions/br_test.exs
@@ -9,17 +9,17 @@ defmodule Holidays.BrTest do
     :ok
   end
 
-  holiday_test("Confraternização Universal", {2018, 1, 1}, :br)
-  holiday_test("Tiradentes", {2018, 4, 21}, :br)
-  holiday_test("Dia do Trabalhador", {2018, 5, 1}, :br)
-  holiday_test("Proclamação da Independência", {2018, 9, 7}, :br)
-  holiday_test("Nossa Senhora Aparecida", {2018, 10, 12}, :br)
-  holiday_test("Proclamação da República", {2018, 11, 15}, :br)
-  holiday_test("Dia da Consciência Negra", {2018, 11, 20}, :br)
-  holiday_test("Natal", {2018, 12, 25}, :br)
-  holiday_test("Carnaval", {2018, 2, 13}, :br)
-  holiday_test("Sexta-feira santa", {2018, 3, 30}, :br)
-  holiday_test("Páscoa", {2018, 4, 1}, :br)
-  holiday_test("Corpus Christi", {2018, 5, 31}, :br)
-  holiday_test("Eleições", {2018, 10, 7}, :br)
+  holiday_test "Confraternização Universal", {2018, 1, 1}, :br
+  holiday_test "Tiradentes", {2018, 4, 21}, :br
+  holiday_test "Dia do Trabalhador", {2018, 5, 1}, :br
+  holiday_test "Proclamação da Independência", {2018, 9, 7}, :br
+  holiday_test "Nossa Senhora Aparecida", {2018, 10, 12}, :br
+  holiday_test "Proclamação da República", {2018, 11, 15}, :br
+  holiday_test "Dia da Consciência Negra", {2018, 11, 20}, :br
+  holiday_test "Natal", {2018, 12, 25}, :br
+  holiday_test "Carnaval", {2018, 2, 13}, :br
+  holiday_test "Sexta-feira santa", {2018, 3, 30}, :br
+  holiday_test "Páscoa", {2018, 4, 1}, :br
+  holiday_test "Corpus Christi", {2018, 5, 31}, :br
+  holiday_test "Eleições", {2018, 10, 7}, :br
 end

--- a/test/holidays/definitions/br_test.exs
+++ b/test/holidays/definitions/br_test.exs
@@ -9,16 +9,17 @@ defmodule Holidays.BrTest do
     :ok
   end
 
-  holiday_test "Confraternização Universal", {2018, 1, 1}, :br
-  holiday_test "Tiradentes", {2018, 4, 21}, :br
-  holiday_test "Dia do Trabalhador", {2018, 5, 1}, :br
-  holiday_test "Proclamação da Independência", {2018, 9, 7}, :br
-  holiday_test "Nossa Senhora Aparecida", {2018, 10, 12}, :br
-  holiday_test "Proclamação da República", {2018, 11, 15}, :br
-  holiday_test "Natal", {2018, 12, 25}, :br
-  holiday_test "Carnaval", {2018, 2, 13}, :br
-  holiday_test "Sexta-feira santa", {2018, 3, 30}, :br
-  holiday_test "Páscoa", {2018, 4, 1}, :br
-  holiday_test "Corpus Christi", {2018, 5, 31}, :br
-  holiday_test "Eleições", {2018, 10, 7}, :br
+  holiday_test("Confraternização Universal", {2018, 1, 1}, :br)
+  holiday_test("Tiradentes", {2018, 4, 21}, :br)
+  holiday_test("Dia do Trabalhador", {2018, 5, 1}, :br)
+  holiday_test("Proclamação da Independência", {2018, 9, 7}, :br)
+  holiday_test("Nossa Senhora Aparecida", {2018, 10, 12}, :br)
+  holiday_test("Proclamação da República", {2018, 11, 15}, :br)
+  holiday_test("Dia da Consciência Negra", {2018, 11, 20}, :br)
+  holiday_test("Natal", {2018, 12, 25}, :br)
+  holiday_test("Carnaval", {2018, 2, 13}, :br)
+  holiday_test("Sexta-feira santa", {2018, 3, 30}, :br)
+  holiday_test("Páscoa", {2018, 4, 1}, :br)
+  holiday_test("Corpus Christi", {2018, 5, 31}, :br)
+  holiday_test("Eleições", {2018, 10, 7}, :br)
 end


### PR DESCRIPTION
in 2023 the holiday was made official

This pull request adds "Dia da Consciência Negra" (Black Awareness Day) as a recognized holiday in Brazil across the codebase and updates the relevant tests to ensure correct functionality.

Holiday addition:

* Added "Dia da Consciência Negra" (November 20) to the list of Brazilian holidays in both the YAML (`definitions/br.yaml`) and Elixir (`lib/holidays/definitions/br.ex`) holiday definitions. [[1]](diffhunk://#diff-ba9e48faaab169d9a29e6a0988f0672f951ddc125ffb589c433cb5d31e156d58R51-R53) [[2]](diffhunk://#diff-09ca825ff1c5f0bb584eeed62371891594e70daa126922eee4cc9e584f047b54R50-R54)

Test updates:

* Added test cases for "Dia da Consciência Negra" in both the Ruby (`definitions/br.yaml`) and Elixir (`test/holidays/definitions/br_test.exs`) test suites to verify correct holiday recognition. [[1]](diffhunk://#diff-ba9e48faaab169d9a29e6a0988f0672f951ddc125ffb589c433cb5d31e156d58R75) [[2]](diffhunk://#diff-f71ad74cafd1ce597de80049824847e9abe6407637dcaac3549da3a289ff2a3dR18)